### PR TITLE
Fix making alacritty fast on hyprland / fix neofetch

### DIFF
--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -214,8 +214,8 @@ allow_remote_control yes
 
 #include ~/.cache/wal/colors-kitty.conf
 #include ~/.config/kitty/background_opacity/background_opacity.conf
-include ~/.config/kitty/colorschemes/hyprland_redblizard_colorscheme.conf
-#include ~/.config/kitty/colorschemes/endeavouros_colorscheme.conf
+#include ~/.config/kitty/colorschemes/hyprland_redblizard_colorscheme.conf
+include ~/.config/kitty/colorschemes/endeavouros_colorscheme.conf
 
 #kitty +kitten icat ~/.config/neofetch/endeavouros-dark.svg
 

--- a/.config/neofetch/config.conf
+++ b/.config/neofetch/config.conf
@@ -124,9 +124,9 @@ memory_display="on"
 battery_display="on"
 disk_display="off"
 
-#image_backend="ascii"
-image_backend="alacritty"
-image_source=$(find $HOME/.config/neofetch/pngs/ -name "*.png" | sort -R | head -1)
+image_backend="ascii"
+#image_backend="alacritty"
+#image_source=$(find $HOME/.config/neofetch/pngs/ -name "*.png" | sort -R | head -1)
 image_size="270px"
 image_loop="off"
 


### PR DESCRIPTION
Change in neofetch config.conf image_backend="ascii" now alacritty does not support image backend by image within neofetch.

Change kitty colorscheme to EOS theme colors.